### PR TITLE
Fix for Charging Port Open Image

### DIFF
--- a/telsa_card.yaml
+++ b/telsa_card.yaml
@@ -99,7 +99,7 @@ cards:
                     left: 50.9%
                     width: 298px
                     height: 298px
-                  image: /local/Tesla/images/buttons/Tesla_ChargePort_Open.jpg
+                  image: /local/Tesla/images/models/3/red/baseChargeportOpened.jpg
             - type: image
               title: Frunk
               image: /local/Tesla/images/buttons/Tesla_Frunk_Closed.jpg


### PR DESCRIPTION
Charging port open image was not displaying. I believe this should point to /local/Tesla/images/models/3/red/baseChargeportOpened.jpg